### PR TITLE
Fix panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add interval check and create shutdown channel in `NewPeriodicRegisterer` [#30](https://github.com/xmidt-org/wrp-listener/pull/30)
 
 ## [v0.2.1]
 - Downgraded uuid version [#19](https://github.com/xmidt-org/wrp-listener/pull/19)

--- a/webhookClient/periodicRegisterer.go
+++ b/webhookClient/periodicRegisterer.go
@@ -18,6 +18,7 @@
 package webhookClient
 
 import (
+	"errors"
 	"time"
 
 	"github.com/xmidt-org/webpa-common/logging"
@@ -49,7 +50,11 @@ var (
 
 // NewPeriodicRegisterer creates a registerer that attempts to register at the
 // interval given.
-func NewPeriodicRegisterer(registerer Registerer, interval time.Duration, logger log.Logger, provider provider.Provider) *PeriodicRegisterer {
+func NewPeriodicRegisterer(registerer Registerer, interval time.Duration, logger log.Logger, provider provider.Provider) (*PeriodicRegisterer, error) {
+	if interval == 0 {
+		return nil, errors.New("interval cannot be 0")
+	}
+
 	if logger == nil {
 		logger = defaultLogger
 	}
@@ -61,7 +66,8 @@ func NewPeriodicRegisterer(registerer Registerer, interval time.Duration, logger
 		registrationInterval: interval,
 		logger:               logger,
 		measures:             m,
-	}
+		shutdown:             make(chan struct{}),
+	}, nil
 }
 
 // Register is just a wrapper to provide the regular Register functionality,

--- a/webhookClient/periodicRegisterer_test.go
+++ b/webhookClient/periodicRegisterer_test.go
@@ -17,4 +17,80 @@
 
 package webhookClient
 
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/xmidt-org/webpa-common/xmetrics/xmetricstest"
+	webhook "github.com/xmidt-org/wrp-listener"
+)
+
 // TODO: add unit tests
+
+func TestNewPeriodicRegisterer(t *testing.T) {
+	mockAcquirer := new(MockAcquirer)
+	mockSecretGetter := new(mockSecretGetter)
+	registry := xmetricstest.NewProvider(nil, Metrics)
+	m := NewMeasures(registry)
+
+	basicRegisterer := BasicRegisterer{
+		acquirer:        mockAcquirer,
+		secretGetter:    mockSecretGetter,
+		requestTemplate: webhook.W{},
+		registrationURL: "random string",
+	}
+
+	logger := log.NewNopLogger()
+	validInterval, _ := time.ParseDuration("10s")
+
+	tests := []struct {
+		description        string
+		registerer         Registerer
+		interval           time.Duration
+		logger             log.Logger
+		expectedRegisterer *PeriodicRegisterer
+		expectedErr        error
+	}{
+		{
+			description: "Success",
+			registerer:  &basicRegisterer,
+			interval:    validInterval,
+			logger:      logger,
+			expectedRegisterer: &PeriodicRegisterer{
+				registerer:           &basicRegisterer,
+				registrationInterval: validInterval,
+				logger:               logger,
+				measures:             m,
+			},
+			expectedErr: nil,
+		},
+		{
+			description:        "0 interval",
+			registerer:         &basicRegisterer,
+			interval:           0,
+			expectedRegisterer: nil,
+			expectedErr:        errors.New("interval cannot be 0"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			pr, err := NewPeriodicRegisterer(tc.registerer, tc.interval, tc.logger, registry)
+			if pr != nil {
+				assert.NotNil(pr.shutdown)
+				tc.expectedRegisterer.shutdown = pr.shutdown
+			}
+
+			assert.Equal(tc.expectedRegisterer, pr)
+			if tc.expectedErr == nil || err == nil {
+				assert.Equal(tc.expectedErr, err)
+			} else {
+				assert.Contains(err.Error(), tc.expectedErr.Error())
+			}
+		})
+	}
+}

--- a/webhookClient/periodicRegisterer_test.go
+++ b/webhookClient/periodicRegisterer_test.go
@@ -81,6 +81,7 @@ func TestNewPeriodicRegisterer(t *testing.T) {
 			assert := assert.New(t)
 			pr, err := NewPeriodicRegisterer(tc.registerer, tc.interval, tc.logger, registry)
 			if pr != nil {
+				//make sure shutdown channel is created
 				assert.NotNil(pr.shutdown)
 				tc.expectedRegisterer.shutdown = pr.shutdown
 			}

--- a/webhookClient/periodicRegisterer_test.go
+++ b/webhookClient/periodicRegisterer_test.go
@@ -68,6 +68,18 @@ func TestNewPeriodicRegisterer(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			description: "Success with Default Logger",
+			registerer:  &basicRegisterer,
+			interval:    validInterval,
+			expectedRegisterer: &PeriodicRegisterer{
+				registerer:           &basicRegisterer,
+				registrationInterval: validInterval,
+				logger:               defaultLogger,
+				measures:             m,
+			},
+			expectedErr: nil,
+		},
+		{
 			description:        "0 interval",
 			registerer:         &basicRegisterer,
 			interval:           0,


### PR DESCRIPTION
This PR:

- adds a check for an interval of 0 in `NewPeriodicRegisterer` and returns an error if it is 0
- Creates the shutdown channel to fix the panic that `Stop` causes

Fixes #29, fixes #28  