### PR TITLE
Replace the auth options with a decorator.

### DIFF
--- a/cmd/bearerListener/main.go
+++ b/cmd/bearerListener/main.go
@@ -85,7 +85,15 @@ func main() {
 	}
 
 	whl, err := listener.New(&r, webhookURL,
-		listener.AuthBearer(os.Getenv("WEBHOOK_BEARER_TOKEN")),
+		listener.DecorateRequest(listener.DecoratorFunc(
+			func(r *http.Request) error {
+				if os.Getenv("WEBHOOK_BEARER_TOKEN") == "" {
+					return nil
+				}
+				r.Header.Set("Authorization", "Bearer "+os.Getenv("WEBHOOK_BEARER_TOKEN"))
+				return nil
+			},
+		)),
 		listener.AcceptSHA1(),
 		listener.Once(),
 		listener.AcceptedSecrets(sharedSecrets...),

--- a/errors.go
+++ b/errors.go
@@ -25,9 +25,8 @@ var (
 	// is not in the list of accepted hashes.
 	ErrNotAcceptedHash = errors.New("not accepted hash")
 
-	// ErrAuthFetchFailed is returned when the auth fetch fails and returns an
-	// error.
-	ErrAuthFetchFailed = errors.New("auth fetch failed")
+	// ErrDecoratorFailed is returned when the decorator returns an error.
+	ErrDecoratorFailed = errors.New("decorator failed")
 
 	// ErrNewRequestFailed is returned when the request cannot be created.
 	ErrNewRequestFailed = errors.New("new request failed")

--- a/example_test.go
+++ b/example_test.go
@@ -78,7 +78,13 @@ func ExampleBasicAuth() { // nolint: govet
 
 	url := server.URL // replace with the URL of the webhook provider
 	whl, err := listener.New(&r, url,
-		listener.AuthBasic("username", "password"),
+		listener.DecorateRequest(listener.DecoratorFunc(
+			func(r *http.Request) error {
+				// Add basic auth headers to the request.
+				r.SetBasicAuth("username", "password")
+				return nil
+			},
+		)),
 		listener.AcceptSHA1(),
 		listener.AcceptedSecrets("foobar", "carport"),
 	)
@@ -126,7 +132,12 @@ func ExampleBearerAuth() { // nolint: govet
 
 	url := server.URL // replace with the URL of the webhook provider
 	whl, err := listener.New(&r, url,
-		listener.AuthBearer(os.Getenv("BEARER_TOKEN")),
+		listener.DecorateRequest(listener.DecoratorFunc(
+			func(r *http.Request) error {
+				r.Header.Set("Authorization", "Bearer "+os.Getenv("BEARER_TOKEN"))
+				return nil
+			},
+		)),
 		listener.AcceptSHA1(),
 		listener.AcceptedSecrets(sharedSecret...),
 	)

--- a/functional_test.go
+++ b/functional_test.go
@@ -68,7 +68,6 @@ func TestNormalUsage(t *testing.T) {
 		},
 		server.URL,
 		Interval(1*time.Millisecond),
-		AuthBasic("user", "pass"),
 	)
 	require.NotNil(whl)
 	require.NoError(err)
@@ -271,7 +270,7 @@ func TestFailedAuthCheck(t *testing.T) {
 			assert.Zero(e.At)
 			assert.Zero(e.Duration)
 			assert.ErrorIs(e.Err, ErrRegistrationNotAttempted)
-			assert.ErrorIs(e.Err, ErrAuthFetchFailed)
+			assert.ErrorIs(e.Err, ErrDecoratorFailed)
 		},
 	}
 
@@ -287,9 +286,11 @@ func TestFailedAuthCheck(t *testing.T) {
 			Duration: webhook.CustomDuration(5 * time.Minute),
 		},
 		"http://example.com",
-		AuthBearerFunc(func() (string, error) {
-			return "", fmt.Errorf("nope")
-		}),
+		DecorateRequest(
+			DecoratorFunc(func(r *http.Request) error {
+				return fmt.Errorf("nope")
+			}),
+		),
 	)
 
 	require.NotNil(whl)
@@ -479,7 +480,6 @@ func TestFailsAfterABit(t *testing.T) {
 		},
 		server.URL,
 		Interval(1*time.Millisecond),
-		AuthBasic("user", "pass"),
 	)
 	require.NotNil(whl)
 	require.NoError(err)

--- a/listener_test.go
+++ b/listener_test.go
@@ -42,17 +42,6 @@ func vadorAcceptedSecrets(ok ...string) vador {
 	}
 }
 
-func vadorGetAuth(want string, err ...error) vador {
-	return func(assert *assert.Assertions, l *Listener) {
-		got, e := l.getAuth()
-		assert.Equal(want, got)
-
-		if err != nil {
-			assert.ErrorIs(e, err[0])
-		}
-	}
-}
-
 var validWHR = webhook.Registration{
 	Duration: webhook.CustomDuration(5 * time.Minute),
 }
@@ -103,7 +92,6 @@ func TestNew(t *testing.T) {
 			checks: []vador{
 				vadorBody,
 				vadorAcceptedSecrets(),
-				vadorGetAuth(""),
 			},
 		}, {
 			description: "nearly empty with an interval is ok",
@@ -112,7 +100,6 @@ func TestNew(t *testing.T) {
 			checks: []vador{
 				vadorBody,
 				vadorAcceptedSecrets(),
-				vadorGetAuth(""),
 			},
 		}, {
 			description: "nearly empty with an invalid interval",

--- a/options_test.go
+++ b/options_test.go
@@ -33,23 +33,11 @@ func TestOptionStrings(t *testing.T) {
 			in:       HTTPClient(nil),
 			expected: "HTTPClient(nil)",
 		}, {
-			in:       AuthBasic("user", "pass"),
-			expected: "AuthBasic(user, ***)",
+			in:       DecorateRequest(nil),
+			expected: "DecorateRequest(nil)",
 		}, {
-			in:       AuthBasicFunc(func() (string, string, error) { return "", "", nil }),
-			expected: "AuthBasicFunc(fn)",
-		}, {
-			in:       AuthBasicFunc(nil),
-			expected: "AuthBasicFunc(nil)",
-		}, {
-			in:       AuthBearer("secret_token"),
-			expected: "AuthBearer(***)",
-		}, {
-			in:       AuthBearerFunc(func() (string, error) { return "", nil }),
-			expected: "AuthBearerFunc(fn)",
-		}, {
-			in:       AuthBearerFunc(nil),
-			expected: "AuthBearerFunc(nil)",
+			in:       DecorateRequest(DecoratorFunc(func(*http.Request) error { return nil })),
+			expected: "DecorateRequest(DecoratorFunc(fn))",
 		}, {
 			in:       AcceptedSecrets("foo"),
 			expected: "AcceptedSecrets(***)",
@@ -108,65 +96,6 @@ func TestHTTPClient(t *testing.T) {
 			check: func(assert *assert.Assertions, l *Listener) {
 				assert.Equal(l.client, http.DefaultClient)
 			},
-		},
-	}
-	commonNewTest(t, tests)
-}
-
-func TestAuth(t *testing.T) {
-	tests := []newTest{
-		{
-			description: "assert default auth is empty",
-			r:           validWHR,
-			check:       vadorGetAuth(""),
-		}, {
-			description: "assert AuthBasic works",
-			r:           validWHR,
-			opt:         AuthBasic("user", "pass"),
-			check:       vadorGetAuth("Basic dXNlcjpwYXNz"),
-		}, {
-			description: "assert AuthBasicFunc works",
-			r:           validWHR,
-			opt: AuthBasicFunc(func() (string, string, error) {
-				return "user", "pass", nil
-			}),
-			check: vadorGetAuth("Basic dXNlcjpwYXNz"),
-		}, {
-			description: "assert AuthBasicFunc handles failure",
-			r:           validWHR,
-			opt: AuthBasicFunc(func() (string, string, error) {
-				return "", "", ErrInput
-			}),
-			check: vadorGetAuth("", ErrInput),
-		}, {
-			description: "assert AuthBasicFunc(nil) works",
-			r:           validWHR,
-			opt:         AuthBasicFunc(nil),
-			check:       vadorGetAuth(""),
-		}, {
-			description: "assert AuthBearer works",
-			r:           validWHR,
-			opt:         AuthBearer("token"),
-			check:       vadorGetAuth("Bearer token"),
-		}, {
-			description: "assert AuthBearerFunc works",
-			r:           validWHR,
-			opt: AuthBearerFunc(func() (string, error) {
-				return "token", nil
-			}),
-			check: vadorGetAuth("Bearer token"),
-		}, {
-			description: "assert AuthBearerFunc(nil) works",
-			r:           validWHR,
-			opt:         AuthBearerFunc(nil),
-			check:       vadorGetAuth(""),
-		}, {
-			description: "assert AuthBearerFunc handles failure",
-			r:           validWHR,
-			opt: AuthBearerFunc(func() (string, error) {
-				return "", ErrInput
-			}),
-			check: vadorGetAuth("", ErrInput),
 		},
 	}
 	commonNewTest(t, tests)


### PR DESCRIPTION
The http.Request decorator is far more flexible than the auth options,
while still making it easy to add auth to a request.